### PR TITLE
Refactor compiler to emit module and runtime to use Transpiler

### DIFF
--- a/src/bunt/compiler.ts
+++ b/src/bunt/compiler.ts
@@ -39,11 +39,16 @@ class Compiler {
   public compile(): CompileResult {
     const body = this.compileAst(this.ast, []);
     const fnName = `render_${this.templateId.replace(/[^\w]/g, "_")}`;
-    const helpersCode =
-      "const h={upper:v=>String(v).toUpperCase(),lower:v=>String(v).toLowerCase(),capitalize:v=>{const s=String(v);return s.charAt(0).toUpperCase()+s.slice(1)},truncate:(v,l=20)=>{const s=String(v);return s.length>l?s.slice(0,l)+'...':s},json:v=>JSON.stringify(v),date:(v,loc,opt)=>{const d=v instanceof Date?v:new Date(String(v));return d.toLocaleDateString(loc,opt)},escapeHtml:v=>String(v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\"/g,'&quot;').replace(/'/g,'&#39;')};";
-    const functionBody = `const helpers={...h,...ctx};return ${body}`;
-    const source = `${helpersCode}export function ${fnName}(ctx){${functionBody}}`;
-    return ok({ source, fnName, functionBody, helpersCode });
+    const source = [
+      'import { standardHelpers } from "../helpers";',
+      'import type { Ctx } from "../types";',
+      `export function ${fnName}(ctx: Ctx): string {`,
+      "  const helpers = { ...standardHelpers, ...ctx };",
+      `  return ${body};`,
+      "}",
+      "",
+    ].join("\n");
+    return ok({ source, fnName });
   }
 
   private compileAst(ast: AST, scope: string[]): string {

--- a/src/bunt/types.ts
+++ b/src/bunt/types.ts
@@ -51,10 +51,6 @@ export type CompileSuccess = {
   source: string;
   /** Name of the generated render function. */
   fnName: string;
-  /** The body of the render function, for use with new Function(). */
-  functionBody: string;
-  /** The JS code for the helpers object, for use with new Function(). */
-  helpersCode: string;
 };
 
 /** Failure payload from compile(). */


### PR DESCRIPTION
## Summary
- generate a full TS module in compiler
- load templates at runtime via `Bun.Transpiler` and dynamic import
- simplify compile result type

## Testing
- `bun x biome lint .`
- `bun x tsc -p tsconfig.json`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6846960b3d6c8320af19a4dcad274e63